### PR TITLE
Increase E2E tests wait time

### DIFF
--- a/kokoro/integration_test.go
+++ b/kokoro/integration_test.go
@@ -305,7 +305,7 @@ func TestAgentIntegration(t *testing.T) {
 				}
 			}()
 
-			timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute*10)
+			timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute*20)
 			defer cancel()
 			if err := gceTr.PollForSerialOutput(timeoutCtx, &tc.InstanceConfig, benchFinishString, errorString); err != nil {
 				t.Fatal(err)

--- a/kokoro/integration_test.sh
+++ b/kokoro/integration_test.sh
@@ -44,8 +44,8 @@ cp -R "kokoro" "$GOPATH/src/proftest"
 cd "$GOPATH/src/proftest"
 retry go get -t -d .
 if [ "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" = "" ]; then
-  go test -timeout=20m -run TestAgentIntegration -commit="$COMMIT" -branch="$BRANCH"
+  go test -timeout=30m -run TestAgentIntegration -commit="$COMMIT" -branch="$BRANCH"
 else
-  go test -timeout=20m -run TestAgentIntegration -commit="$COMMIT" -pr="$KOKORO_GITHUB_PULL_REQUEST_NUMBER"
+  go test -timeout=30m -run TestAgentIntegration -commit="$COMMIT" -pr="$KOKORO_GITHUB_PULL_REQUEST_NUMBER"
 fi
 


### PR DESCRIPTION
APT repository slowness sometimes causes the test to time out and fail. 