### PR TITLE
fix(deps): require protobuf < 4.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     'google-api-python-client!=1.12.0,!=2.0.2',
     'google-auth>=1.0.0',
     'google-auth-httplib2',
-    'protobuf',
+    'protobuf<4.0.0dev',
     'requests',
 ]
 


### PR DESCRIPTION
Fixes the following error from this [build log](https://fusion2.corp.google.com/invocations/3faa928f-e9d7-4a36-9de4-2b2fadbbabb6/log).

```
            Wed Jun 22 13:13:11 UTC 2022: Traceback (most recent call last):
            Wed Jun 22 13:13:11 UTC 2022: File "/bench/bench.py", line 1, in <module>
            Wed Jun 22 13:13:11 UTC 2022: import googlecloudprofiler
            Wed Jun 22 13:13:11 UTC 2022: File "/root/.local/share/virtualenvs/bench-9eqDOt4H/lib/python3.9/site-packages/googlecloudprofiler/__init__.py", line 19, in <module>
            Wed Jun 22 13:13:11 UTC 2022: from googlecloudprofiler import client
            Wed Jun 22 13:13:11 UTC 2022: File "/root/.local/share/virtualenvs/bench-9eqDOt4H/lib/python3.9/site-packages/googlecloudprofiler/client.py", line 37, in <module>
            Wed Jun 22 13:13:11 UTC 2022: from googlecloudprofiler import cpu_profiler
            Wed Jun 22 13:13:11 UTC 2022: File "/root/.local/share/virtualenvs/bench-9eqDOt4H/lib/python3.9/site-packages/googlecloudprofiler/cpu_profiler.py", line 18, in <module>
            Wed Jun 22 13:13:11 UTC 2022: from googlecloudprofiler import builder
            Wed Jun 22 13:13:11 UTC 2022: File "/root/.local/share/virtualenvs/bench-9eqDOt4H/lib/python3.9/site-packages/googlecloudprofiler/builder.py", line 19, in <module>
            Wed Jun 22 13:13:11 UTC 2022: from googlecloudprofiler import profile_pb2
            Wed Jun 22 13:13:11 UTC 2022: File "/root/.local/share/virtualenvs/bench-9eqDOt4H/lib/python3.9/site-packages/googlecloudprofiler/profile_pb2.py", line 46, in <module>
            Wed Jun 22 13:13:11 UTC 2022: _descriptor.FieldDescriptor(
            Wed Jun 22 13:13:11 UTC 2022: File "/root/.local/share/virtualenvs/bench-9eqDOt4H/lib/python3.9/site-packages/google/protobuf/descriptor.py", line 560, in __new__
            Wed Jun 22 13:13:11 UTC 2022: _message.Message._CheckCalledFromGeneratedFile()
            Wed Jun 22 13:13:11 UTC 2022: TypeError: Descriptors cannot not be created directly.
            Wed Jun 22 13:13:11 UTC 2022: If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
            Wed Jun 22 13:13:11 UTC 2022: If you cannot immediately regenerate your protos, some other possible workarounds are:
            Wed Jun 22 13:13:11 UTC 2022: 1. Downgrade the protobuf package to 3.20.x or lower.
            Wed Jun 22 13:13:11 UTC 2022: 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
            Wed Jun 22 13:13:11 UTC 2022: 
```